### PR TITLE
Upgrade yaml-cpp usage to the new API (version 0.5 and later)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ from the [uap-core](https://github.com/ua-parser/uap-core) repository in the ins
 that you don't complete this step, the uaparser will attempt to download the YAML file into a temporary directory
 when called, but this is less efficient and not workable for machines without a direct internet connection.
 
-Follow the instructions on [this wiki page](https://github.com/ua-parser/uap-r/wiki/Installing-uaparser-on-Mac-OS-X)  if you are seeing errors related to yaml-cpp when attempting to install uaparser on OS X.
+This package no longer works with the old (pre-0.5) version of the `yaml-cpp` library. You will need version 0.5 or later.
 
 Dependencies
 ======
@@ -26,7 +26,7 @@ Dependencies
 * [downloader](http://cran.r-project.org/web/packages/downloader/index.html);
 * The [boost-regex](http://www.boost.org/doc/libs/1_57_0/libs/regex/doc/html/index.html) C++ library;
 * The [boost-system](http://www.boost.org/doc/libs/1_57_0/libs/system/doc/index.html) C++ library;
-* The [libyaml-cpp 0.3](https://code.google.com/p/yaml-cpp/) C++ library;
+* The [libyaml-cpp](https://github.com/jbeder/yaml-cpp/) C++ library, version 0.5 or later.
 
 Contributing upstream
 ======

--- a/src/internal_UaParser.cpp
+++ b/src/internal_UaParser.cpp
@@ -25,8 +25,8 @@ typedef AgentStore BrowserStore;
 
 #define FILL_AGENT_STORE(node, agent_store, repl, maj_repl, min_repl)    \
     for (auto it = node.begin(); it != node.end(); ++it) {               \
-      const std::string key = it.first().to<std::string>();              \
-      const std::string value = it.second().to<std::string>();           \
+      const std::string key = it->first.as<std::string>();              \
+      const std::string value = it->second.as<std::string>();           \
       if (key == "regex") {                                              \
         agent_store.regExpr = value;                                     \
       } else if (key == repl) {                                          \
@@ -67,8 +67,8 @@ struct UAStore {
     for (const auto& d : device_parsers) {
       DeviceStore device;
       for (auto it = d.begin(); it != d.end(); ++it) {
-        const std::string key = it.first().to<std::string>();
-        const std::string value = it.second().to<std::string>();
+        const std::string key = it->first.as<std::string>();
+        const std::string value = it->second.as<std::string>();
         if (key == "regex") {
           device.regExpr = value;
         } else if (key == "device_replacement") {


### PR DESCRIPTION
I've ported the existing code to the new `yaml-cpp` API, present in version 0.5 onwards, and tested it on my local machine. This upgrade should make it quite a lot easier for users to get this package installed, and obviate the need for some of the workarounds in the wiki.

I also took the liberty of updating the documentation -- I hope that's ok.

Some further comments:

* I haven't gotten boost-regex, c++11, and R working nicely on my local machine, so my own testing has been with `std::regex` instead of `boost::regex`. So it might be a good idea to test this before merging.

* The file `internal_UaParser.cpp` and `internal_UaParser.h` appear to be dead code, so although Ive ported them I'm not actually sure they will work. 

* Due to an annoying bug upstream in `yaml-cpp`, there are quite a number of `try-catch` blocks. These can be removed in future versions, since the API does not actually require them.

This should address #4.